### PR TITLE
Apply Demo Retailer branding to header elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Demo Header Logo Hider
 
-A local Chrome extension that toggles the visibility of the header logo element
-used in Criteo Retail Media demos. When enabled, it removes any element matching
-the selector:
-
-```
-body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > div.toolbar-left > app-header-logo > img
-```
+A local Chrome extension that applies "Demo Retailer" branding to key elements
+used in Criteo Retail Media demos. When enabled, it replaces the header logo with
+an inline "Demo Retailer" logo and updates the account name text. The original
+content is restored when the toggle is turned off.
 
 ## Getting started
 
@@ -28,11 +25,12 @@ body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-
 
 ## Usage
 
-* Open the extension popup and use the toggle to hide or show the header logo.
+* Open the extension popup and use the toggle to apply or restore the Demo
+  Retailer branding.
 * The setting is stored using `chrome.storage.sync`, so it persists across page
   refreshes and browser restarts.
-* While enabled, a MutationObserver keeps the target element hidden even if the
-  page re-renders dynamically.
+* While enabled, a MutationObserver reapplies the branding even if the page
+  re-renders dynamically.
 
 ## Development notes
 
@@ -40,4 +38,3 @@ body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-
 * Toolbar icons are generated using the Python standard library and stored in
   the `extension/icons/` directory.
 * To update the icons, edit `scripts/generate_icons.py` and run it again.
-

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -3,8 +3,8 @@ const statusElement = document.getElementById("status");
 
 function updateStatus(enabled) {
   statusElement.textContent = enabled
-    ? "The header logo is hidden on supported pages."
-    : "The header logo is visible.";
+    ? "Demo Retailer branding is applied on supported pages."
+    : "Default site branding is shown.";
 }
 
 function applyState(enabled) {

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -1,10 +1,21 @@
-const TARGET_SELECTOR = "body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > div.toolbar-left > app-header-logo > img";
+const LOGO_SELECTOR = "body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > div.toolbar-left > app-header-logo > img";
+const ACCOUNT_NAME_SELECTOR =
+  "body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > app-header-right > app-header-account > a.mat-mdc-tooltip-trigger.with-account-name.mdc-button.mat-mdc-button.mat-secondary.mat-mdc-button-base.cds-secondary.ng-star-inserted > span.mdc-button__label > span";
+
 const HIDDEN_ATTR = "data-demo-hider-hidden";
 const DISPLAY_VALUE_ATTR = "data-demo-hider-display";
 const DISPLAY_PRIORITY_ATTR = "data-demo-hider-display-priority";
+const ORIGINAL_TEXT_ATTR = "data-demo-hider-original-text";
+
+const LOGO_WIDTH = 300;
+const LOGO_HEIGHT = 100;
+const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="${LOGO_WIDTH}" height="${LOGO_HEIGHT}" viewBox="0 0 ${LOGO_WIDTH} ${LOGO_HEIGHT}"><rect width="100%" height="100%" fill="white"/><text x="50%" y="50%" fill="#FF6C00" font-family="Segoe UI, Arial, sans-serif" font-size="36" font-weight="600" dominant-baseline="middle" text-anchor="middle">Demo Retailer</text></svg>`;
+const LOGO_DATA_URL = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(LOGO_SVG)}`;
+const CUSTOM_LOGO_ATTR = "data-demo-hider-custom-logo";
 
 let enabled = false;
 let observer;
+const customLogos = new WeakMap();
 
 function hideElement(element) {
   if (!element || element.hasAttribute(HIDDEN_ATTR)) {
@@ -49,21 +60,94 @@ function restoreElement(element) {
   element.removeAttribute(DISPLAY_PRIORITY_ATTR);
 }
 
-function hideMatchingElements() {
-  const elements = document.querySelectorAll(TARGET_SELECTOR);
-  elements.forEach((element) => hideElement(element));
+function ensureCustomLogo(originalElement) {
+  if (!originalElement) {
+    return;
+  }
+
+  hideElement(originalElement);
+
+  if (customLogos.has(originalElement)) {
+    const placeholder = customLogos.get(originalElement);
+    if (placeholder && !placeholder.isConnected && originalElement.parentNode) {
+      originalElement.parentNode.insertBefore(placeholder, originalElement.nextSibling);
+    }
+    return;
+  }
+
+  if (!originalElement.parentNode) {
+    return;
+  }
+
+  const placeholder = document.createElement("img");
+  placeholder.src = LOGO_DATA_URL;
+  placeholder.alt = "Demo Retailer";
+  placeholder.width = LOGO_WIDTH;
+  placeholder.height = LOGO_HEIGHT;
+  placeholder.setAttribute(CUSTOM_LOGO_ATTR, "true");
+  placeholder.style.setProperty("max-width", "100%");
+  placeholder.style.setProperty("height", "auto");
+
+  originalElement.parentNode.insertBefore(placeholder, originalElement.nextSibling);
+  customLogos.set(originalElement, placeholder);
 }
 
-function restoreMatchingElements() {
-  const elements = document.querySelectorAll(TARGET_SELECTOR);
-  elements.forEach((element) => restoreElement(element));
+function removeCustomLogo(originalElement) {
+  const placeholder = customLogos.get(originalElement);
+  if (placeholder) {
+    if (placeholder.parentNode) {
+      placeholder.parentNode.removeChild(placeholder);
+    }
+    customLogos.delete(originalElement);
+  }
+
+  restoreElement(originalElement);
+}
+
+function applyCustomAccountName(element) {
+  if (!element) {
+    return;
+  }
+
+  if (!element.hasAttribute(ORIGINAL_TEXT_ATTR)) {
+    const originalText = element.textContent ?? "";
+    element.setAttribute(ORIGINAL_TEXT_ATTR, originalText);
+  }
+
+  element.textContent = "Demo Retailer";
+}
+
+function restoreAccountName(element) {
+  if (!element || !element.hasAttribute(ORIGINAL_TEXT_ATTR)) {
+    return;
+  }
+
+  const originalText = element.getAttribute(ORIGINAL_TEXT_ATTR);
+  element.textContent = originalText ?? "";
+  element.removeAttribute(ORIGINAL_TEXT_ATTR);
+}
+
+function applyCustomizations() {
+  const logoElements = document.querySelectorAll(LOGO_SELECTOR);
+  logoElements.forEach((element) => ensureCustomLogo(element));
+
+  const accountNameElements = document.querySelectorAll(ACCOUNT_NAME_SELECTOR);
+  accountNameElements.forEach((element) => applyCustomAccountName(element));
+}
+
+function restoreCustomizations() {
+  const logoElements = document.querySelectorAll(LOGO_SELECTOR);
+  logoElements.forEach((element) => removeCustomLogo(element));
+
+  const accountNameElements = document.querySelectorAll(ACCOUNT_NAME_SELECTOR);
+  accountNameElements.forEach((element) => restoreAccountName(element));
 }
 
 function updateVisibility() {
   if (enabled) {
-    hideMatchingElements();
+    applyCustomizations();
   } else {
-    restoreMatchingElements();
+    restoreCustomizations();
   }
 }
 
@@ -74,7 +158,7 @@ function ensureObserver() {
 
   observer = new MutationObserver(() => {
     if (enabled) {
-      hideMatchingElements();
+      applyCustomizations();
     }
   });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Demo Header Logo Hider",
-  "description": "Toggle hiding of the demo header logo element by selector for local presentations.",
+  "description": "Apply Demo Retailer branding to the header logo and account name on supported pages.",
   "version": "1.0.0",
   "permissions": [
     "storage"


### PR DESCRIPTION
## Summary
- replace the header logo with an inline Demo Retailer SVG and update the account name when the extension is enabled
- keep the original elements for restoration when disabled and refresh popup messaging/manifest copy
- document the new behavior in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cac99ec33c83339a256a419ffdf6f1