### PR TITLE
Adjust account name selector to use data attribute

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -1,6 +1,5 @@
 const LOGO_SELECTOR = "body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > div.toolbar-left > app-header-logo > img";
-const ACCOUNT_NAME_SELECTOR =
-  "body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > app-header-right > app-header-account > a.mat-mdc-tooltip-trigger.with-account-name.mdc-button.mat-mdc-button.mat-secondary.mat-mdc-button-base.cds-secondary.ng-star-inserted > span.mdc-button__label > span";
+const ACCOUNT_NAME_SELECTOR = '[data-test="headerAccountListButtonText"]';
 
 const HIDDEN_ATTR = "data-demo-hider-hidden";
 const DISPLAY_VALUE_ATTR = "data-demo-hider-display";


### PR DESCRIPTION
## Summary
- simplify the account name selector to target the headerAccountListButtonText span via its data-test attribute
- continue replacing the account label text with the Demo Retailer branding when enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cacd6855b08333b9ba1e80d1f43450