### PR TITLE
Replace logo swap with inline data URL

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -1,106 +1,64 @@
 const LOGO_SELECTOR = "body > app-root > app-shell > mat-sidenav-container > mat-sidenav-content > app-header > div > mat-toolbar > div.toolbar-left > app-header-logo > img";
 const ACCOUNT_NAME_SELECTOR = '[data-test="headerAccountListButtonText"]';
 
-const HIDDEN_ATTR = "data-demo-hider-hidden";
-const DISPLAY_VALUE_ATTR = "data-demo-hider-display";
-const DISPLAY_PRIORITY_ATTR = "data-demo-hider-display-priority";
-const ORIGINAL_TEXT_ATTR = "data-demo-hider-original-text";
-
 const LOGO_WIDTH = 300;
 const LOGO_HEIGHT = 100;
 const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="${LOGO_WIDTH}" height="${LOGO_HEIGHT}" viewBox="0 0 ${LOGO_WIDTH} ${LOGO_HEIGHT}"><rect width="100%" height="100%" fill="white"/><text x="50%" y="50%" fill="#FF6C00" font-family="Segoe UI, Arial, sans-serif" font-size="36" font-weight="600" dominant-baseline="middle" text-anchor="middle">Demo Retailer</text></svg>`;
 const LOGO_DATA_URL = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(LOGO_SVG)}`;
 const CUSTOM_LOGO_ATTR = "data-demo-hider-custom-logo";
+const ORIGINAL_TEXT_ATTR = "data-demo-hider-original-text";
 
 let enabled = false;
 let observer;
 const customLogos = new WeakMap();
-
-function hideElement(element) {
-  if (!element || element.hasAttribute(HIDDEN_ATTR)) {
-    return;
-  }
-
-  const currentDisplay = element.style.getPropertyValue("display");
-  const currentPriority = element.style.getPropertyPriority("display");
-
-  if (currentDisplay) {
-    element.setAttribute(DISPLAY_VALUE_ATTR, currentDisplay);
-  } else {
-    element.removeAttribute(DISPLAY_VALUE_ATTR);
-  }
-
-  if (currentPriority) {
-    element.setAttribute(DISPLAY_PRIORITY_ATTR, currentPriority);
-  } else {
-    element.removeAttribute(DISPLAY_PRIORITY_ATTR);
-  }
-
-  element.setAttribute(HIDDEN_ATTR, "true");
-  element.style.setProperty("display", "none", "important");
-}
-
-function restoreElement(element) {
-  if (!element || !element.hasAttribute(HIDDEN_ATTR)) {
-    return;
-  }
-
-  const originalDisplay = element.getAttribute(DISPLAY_VALUE_ATTR);
-  const originalPriority = element.getAttribute(DISPLAY_PRIORITY_ATTR) || "";
-
-  if (originalDisplay !== null && originalDisplay !== "") {
-    element.style.setProperty("display", originalDisplay, originalPriority);
-  } else {
-    element.style.removeProperty("display");
-  }
-
-  element.removeAttribute(HIDDEN_ATTR);
-  element.removeAttribute(DISPLAY_VALUE_ATTR);
-  element.removeAttribute(DISPLAY_PRIORITY_ATTR);
-}
 
 function ensureCustomLogo(originalElement) {
   if (!originalElement) {
     return;
   }
 
-  hideElement(originalElement);
+  if (!customLogos.has(originalElement)) {
+    const originalAttributes = {
+      src: originalElement.getAttribute("src"),
+      srcset: originalElement.getAttribute("srcset"),
+      alt: originalElement.getAttribute("alt")
+    };
 
-  if (customLogos.has(originalElement)) {
-    const placeholder = customLogos.get(originalElement);
-    if (placeholder && !placeholder.isConnected && originalElement.parentNode) {
-      originalElement.parentNode.insertBefore(placeholder, originalElement.nextSibling);
-    }
-    return;
+    customLogos.set(originalElement, originalAttributes);
   }
 
-  if (!originalElement.parentNode) {
-    return;
-  }
-
-  const placeholder = document.createElement("img");
-  placeholder.src = LOGO_DATA_URL;
-  placeholder.alt = "Demo Retailer";
-  placeholder.width = LOGO_WIDTH;
-  placeholder.height = LOGO_HEIGHT;
-  placeholder.setAttribute(CUSTOM_LOGO_ATTR, "true");
-  placeholder.style.setProperty("max-width", "100%");
-  placeholder.style.setProperty("height", "auto");
-
-  originalElement.parentNode.insertBefore(placeholder, originalElement.nextSibling);
-  customLogos.set(originalElement, placeholder);
+  originalElement.setAttribute("src", LOGO_DATA_URL);
+  originalElement.removeAttribute("srcset");
+  originalElement.setAttribute("alt", "Demo Retailer");
+  originalElement.setAttribute(CUSTOM_LOGO_ATTR, "true");
 }
 
 function removeCustomLogo(originalElement) {
-  const placeholder = customLogos.get(originalElement);
-  if (placeholder) {
-    if (placeholder.parentNode) {
-      placeholder.parentNode.removeChild(placeholder);
-    }
-    customLogos.delete(originalElement);
+  const originalAttributes = customLogos.get(originalElement);
+  if (!originalAttributes) {
+    return;
   }
 
-  restoreElement(originalElement);
+  if (originalAttributes.src !== null) {
+    originalElement.setAttribute("src", originalAttributes.src);
+  } else {
+    originalElement.removeAttribute("src");
+  }
+
+  if (originalAttributes.srcset !== null && originalAttributes.srcset !== "") {
+    originalElement.setAttribute("srcset", originalAttributes.srcset);
+  } else {
+    originalElement.removeAttribute("srcset");
+  }
+
+  if (originalAttributes.alt !== null) {
+    originalElement.setAttribute("alt", originalAttributes.alt);
+  } else {
+    originalElement.removeAttribute("alt");
+  }
+
+  originalElement.removeAttribute(CUSTOM_LOGO_ATTR);
+  customLogos.delete(originalElement);
 }
 
 function applyCustomAccountName(element) {


### PR DESCRIPTION
## Summary
- update the content script to store and restore the original header logo attributes
- swap the logo source with an inline Demo Retailer image instead of hiding the element and inserting a placeholder

## Testing
- not run (extension code change)


------
https://chatgpt.com/codex/tasks/task_e_68cacf0a4ba08333ac850a50e7925773