### PR TITLE
Prevent repeated text updates causing mutation loop

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -75,6 +75,10 @@ function applyCustomAccountName(element) {
     element.setAttribute(ORIGINAL_TEXT_ATTR, originalText);
   }
 
+  if (element.textContent === "Demo Retailer") {
+    return;
+  }
+
   element.textContent = "Demo Retailer";
 }
 


### PR DESCRIPTION
## Summary
- avoid reapplying the Demo Retailer label when the account name already matches
- prevent repeated MutationObserver callbacks that caused the page to hang when enabling the text override

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb22224f408333b2795cfd69700174