### PR TITLE
Skip renaming dash-only retailer cells

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -262,6 +262,10 @@ function applyRetailerCellCustomizations() {
       return;
     }
 
+    if (trimmedText === "-") {
+      return;
+    }
+
     const currentHTML = element.innerHTML;
     const storedOriginal = retailerCellOriginalContent.get(element);
 


### PR DESCRIPTION
## Summary
- avoid replacing retailer table entries whose text content is just a dash
- keep existing logic for other retailer cells unchanged

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb398113788333bd5900ad6ca7dc59