### PR TITLE
Expand retailer column selector

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -4,8 +4,7 @@ const ACCOUNT_NAME_SELECTORS = [
   '[data-test="headerAccountListButtonText"]',
   "span.cds-p1-bold"
 ];
-const RETAILER_COLUMN_CELL_SELECTOR =
-  ".mat-mdc-cell.mdc-data-table__cell.cdk-cell.cdk-column-retailers.mat-column-retailers.ng-star-inserted";
+const RETAILER_COLUMN_CELL_SELECTOR = "[class*='column-retailers']";
 const RETAILER_COLUMN_TEXT_SELECTOR =
   `${RETAILER_COLUMN_CELL_SELECTOR} .cds-display-block`;
 const EXCLUDED_TEXT_PARENT_NODES = new Set([


### PR DESCRIPTION
## Summary
- expand the retailer column selector to match any element whose class attribute contains `column-retailers`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb3c590414833392674b7a09b07c57