### PR TITLE
Enable content script in all frames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
       "js": [
         "extension/scripts/content.js"
       ],
+      "all_frames": true,
       "run_at": "document_idle"
     }
   ]


### PR DESCRIPTION
## Summary
- allow the content script to run within all frames on matching pages by enabling the all_frames flag

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb587f7c30833384d0cb25c5d77d72